### PR TITLE
Feat/functional segmentation masks

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -133,10 +133,10 @@ def load_sparse_array(h5_file):
 
 def convert_rois_to_segmentation_mask(h5_file):
     pixelmasks = load_sparse_array(h5_file)
-    segmetation_mask = np.zeros(pixelmasks.shape[1:], dtype="i2")
+    segmentation_mask = np.zeros(pixelmasks.shape[1:], dtype="i2")
     contains_roi = pixelmasks.sum(0) > 0
-    segmetation_mask[contains_roi] = np.argmax(pixelmasks[:, contains_roi], 0) + 1
-    return segmetation_mask
+    segmentation_mask[contains_roi] = np.argmax(pixelmasks[:, contains_roi], 0) + 1
+    return segmentation_mask
 
 
 def get_segementation_approach(extraction_h5: Path) -> SegmentationApproach:
@@ -341,18 +341,18 @@ def nwb_ophys(
             description="Max intensity projection of entire session",
         )
         if segmentation_approach == SegmentationApproach.SUITE2P_ANATOMICAL:
-            segmetation_mask = load_generic_group(
+            segmentation_mask = load_generic_group(
                 file_paths["planes"][plane_name]["extraction_h5"],
                 h5_group="cellpose",
                 h5_key="masks",
             )
         else:
-            segmetation_mask = convert_rois_to_segmentation_mask(
+            segmentation_mask = convert_rois_to_segmentation_mask(
                 file_paths["planes"][plane_name]["extraction_h5"]
             )
         mask_img = GrayscaleImage(
             name="segmentation_mask_image",
-            data=segmetation_mask,
+            data=segmentation_mask,
             resolution=float(plane["fov_scale_factor"]),  # pixels/cm
             description="Segmentation projection of entire session",
         )

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -131,6 +131,14 @@ def load_sparse_array(h5_file):
     return pixelmasks
 
 
+def convert_rois_to_segmentation_mask(h5_file):
+    pixelmasks = load_sparse_array(h5_file)
+    segmetation_mask = np.zeros(pixelmasks.shape[1:], dtype="i2")
+    contains_roi = pixelmasks.sum(0) > 0
+    segmetation_mask[contains_roi] = np.argmax(pixelmasks[:, contains_roi], 0) + 1
+    return segmetation_mask
+
+
 def get_segementation_approach(extraction_h5: Path) -> SegmentationApproach:
     """Get the segmentation approach from the extraction file
 
@@ -339,7 +347,9 @@ def nwb_ophys(
                 h5_key="masks",
             )
         else:
-            raise NotImplementedError("Cannot process functional segmentation")
+            segmetation_mask = convert_rois_to_segmentation_mask(
+                file_paths["planes"][plane_name]["extraction_h5"]
+            )
         mask_img = GrayscaleImage(
             name="segmentation_mask_image",
             data=segmetation_mask,


### PR DESCRIPTION
Currently the NWB capsule crashes for functional Suite2p or CaImAn due to the lacking `segmentation_mask`.

Please, either create the NWB without it, or use this code to create the `segmentation_mask` for the NWB from the ROIs if Cellpose is not used.

I verified that if Cellpose is used, the result of my `convert_rois_to_segmentation_mask` is identical to the `cellpose/masks` array.