### PR TITLE
feat: attempt to generate neuropil masks, get r values, and add to nwb

### DIFF
--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -6,12 +6,12 @@
 			"mount": "nwb"
 		},
 		{
-			"id": "56b00205-387b-44f8-926c-abfefe52ab4a",
-			"mount": "multiplane-ophys_731327_2024-08-21_14-38-32"
+			"id": "6ba7d1d4-8fc7-4367-a270-d931ea2ead1b",
+			"mount": "raw"
 		},
 		{
-			"id": "9fe5c0b8-2a5d-49a7-bb1b-9ac68d0da333",
-			"mount": "multiplane-ophys_731327_2024-08-21_14-38-32_processed_2024-11-01_08-42-49"
+			"id": "cb872a19-4c11-4a4c-abcd-e19b06f0773e",
+			"mount": "processed"
 		},
 		{
 			"id": "fb4b5cef-4505-4145-b8bd-e41d6863d7a9",

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -29,6 +29,7 @@ from pynwb.image import GrayscaleImage, Images, ImageSeries
 from pynwb.ophys import (
     DfOverF,
     Fluorescence,
+    ImagingPlane,
     ImageSegmentation,
     OpticalChannel,
     RoiResponseSeries,
@@ -236,6 +237,65 @@ def load_sparse_array(h5_file):
 
     pixelmasks = sparse.COO(coords, data, shape).todense()
     return pixelmasks
+
+
+def load_neuropil_masks(h5_file: Path) -> np.ndarray:
+    """Load neuropil pixel masks from the h5 file
+
+    Parameters
+    ----------
+    h5_file : Path
+        The path to the h5 file
+
+    Returns
+    -------
+    np.ndarray
+        Dense array of shape (n_rois, height, width) with neuropil masks
+    """
+    with h5py.File(h5_file, "r") as f:
+        indices = f["rois"]["neuropil_coords"][:].T
+        shape = f["rois"]["shape"][:]
+    neuropil_mask = np.zeros(shape)
+    neuropil_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = 1
+    return neuropil_mask
+
+
+def add_neuropil_segmentation(
+    extraction_h5: Path,
+    segmentation_approach: SegmentationApproach,
+    img_seg: ImageSegmentation,
+    imaging_plane: ImagingPlane,
+) -> None:
+    """Add neuropil segmentation masks to an ImageSegmentation object.
+
+    Only runs for suite2p-based segmentation approaches.
+
+    Parameters
+    ----------
+    extraction_h5 : Path
+        Path to the extraction HDF5 file containing neuropil coords.
+    segmentation_approach : SegmentationApproach
+        The segmentation approach used.
+    img_seg : ImageSegmentation
+        The NWB ImageSegmentation object to add the plane segmentation to.
+    imaging_plane : ImagingPlane
+        The NWB ImagingPlane associated with this segmentation.
+    """
+    try:
+        if segmentation_approach in (
+            SegmentationApproach.SUITE2P_ANATOMICAL,
+            SegmentationApproach.SUITE2P_ACTIVITY,
+        ):
+            neuropil_masks = load_neuropil_masks(extraction_h5)
+            neuropil_plane_segmentation = img_seg.create_plane_segmentation(
+                name="neuropil_masks",
+                description="Neuropil segmentation masks from suite2p",
+                imaging_plane=imaging_plane,
+            )
+            for neuropil_mask in neuropil_masks:
+                neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
+    except Exception as e:
+        logging.warning(f"Error adding neuropil segmentation masks: {e}")
 
 
 def convert_rois_to_segmentation_mask(h5_file):
@@ -500,6 +560,13 @@ def nwb_ophys_single_plane(
             )
         ):
             plane_segmentation.add_roi(image_mask=pixel_mask)
+
+    add_neuropil_segmentation(
+        file_paths["planes"][plane_name]["extraction_h5"],
+        segmentation_approach,
+        img_seg,
+        imaging_plane,
+    )
 
     ophys_module.add(img_seg)
 
@@ -800,6 +867,14 @@ def nwb_ophys(
                 "dendrite_probability",
             ],
         )
+
+        add_neuropil_segmentation(
+            file_paths["planes"][plane_name]["extraction_h5"],
+            segmentation_approach,
+            img_seg,
+            imaging_plane,
+        )
+
         ophys_module.add(img_seg)
 
         avg_projection = plt.imread(

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -267,50 +267,35 @@ def load_neuropil_masks_and_r_values(h5_file: Path) -> tuple[np.ndarray, np.ndar
 
 def add_neuropil_segmentation_and_r_values(
     extraction_h5: Path,
-    segmentation_approach: SegmentationApproach,
     img_seg: ImageSegmentation,
     imaging_plane: ImagingPlane,
 ) -> None:
     """Add neuropil segmentation masks and r-values to an ImageSegmentation object.
 
-    Only runs for suite2p-based segmentation approaches.
-
     Parameters
     ----------
     extraction_h5 : Path
         Path to the extraction HDF5 file containing neuropil coords.
-    segmentation_approach : SegmentationApproach
-        The segmentation approach used.
     img_seg : ImageSegmentation
         The NWB ImageSegmentation object to add the plane segmentation to.
     imaging_plane : ImagingPlane
         The NWB ImagingPlane associated with this segmentation.
     """
     try:
-        if segmentation_approach in (
-            SegmentationApproach.SUITE2P_ANATOMICAL,
-            SegmentationApproach.SUITE2P_ACTIVITY,
-        ):
-            neuropil_masks, r_values = load_neuropil_masks_and_r_values(extraction_h5)
-            neuropil_plane_segmentation = img_seg.create_plane_segmentation(
-                name="neuropil_masks",
-                description="Neuropil segmentation masks from suite2p",
-                imaging_plane=imaging_plane,
-            )
-            for neuropil_mask in neuropil_masks:
-                neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
+        neuropil_masks, r_values = load_neuropil_masks_and_r_values(extraction_h5)
+        neuropil_plane_segmentation = img_seg.create_plane_segmentation(
+            name="neuropil_masks",
+            description="Neuropil segmentation masks from suite2p",
+            imaging_plane=imaging_plane,
+        )
+        for neuropil_mask in neuropil_masks:
+            neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
 
-            neuropil_plane_segmentation.add_column(
-                name="neuropil_r_value",
-                description="Coefficients used for neuropil correction",
-                data=r_values
-            )
-        else:
-            logging.info(
-                "Skipping neuropil segmentation. Currently only supported "
-                "for suite2p-based segmentation approaches. "
-                f"Segmentation approach used: {segmentation_approach}"
-            )
+        neuropil_plane_segmentation.add_column(
+            name="neuropil_r_value",
+            description="Coefficients used for neuropil correction",
+            data=r_values
+        )
     except Exception as e:
         logging.warning(f"Error adding neuropil segmentation masks: {e}")
 
@@ -578,12 +563,21 @@ def nwb_ophys_single_plane(
         ):
             plane_segmentation.add_roi(image_mask=pixel_mask)
 
-    add_neuropil_segmentation_and_r_values(
-        file_paths["planes"][plane_name]["extraction_h5"],
-        segmentation_approach,
-        img_seg,
-        imaging_plane,
-    )
+    if segmentation_approach in (
+        SegmentationApproach.SUITE2P_ANATOMICAL,
+        SegmentationApproach.SUITE2P_ACTIVITY,
+    ):
+        add_neuropil_segmentation_and_r_values(
+            file_paths["planes"][plane_name]["extraction_h5"],
+            img_seg,
+            imaging_plane,
+        )
+    else:
+        logging.info(
+            "Skipping neuropil segmentation. Currently only supported "
+            "for suite2p-based segmentation approaches. "
+            f"Segmentation approach used: {segmentation_approach}"
+        )
 
     ophys_module.add(img_seg)
 
@@ -885,12 +879,21 @@ def nwb_ophys(
             ],
         )
 
-        add_neuropil_segmentation_and_r_values(
-            file_paths["planes"][plane_name]["extraction_h5"],
-            segmentation_approach,
-            img_seg,
-            imaging_plane,
-        )
+        if segmentation_approach in (
+            SegmentationApproach.SUITE2P_ANATOMICAL,
+            SegmentationApproach.SUITE2P_ACTIVITY,
+        ):
+            add_neuropil_segmentation_and_r_values(
+                file_paths["planes"][plane_name]["extraction_h5"],
+                img_seg,
+                imaging_plane,
+            )
+        else:
+            logging.info(
+                "Skipping neuropil segmentation. Currently only supported "
+                "for suite2p-based segmentation approaches. "
+                f"Segmentation approach used: {segmentation_approach}"
+            )
 
         ophys_module.add(img_seg)
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -269,8 +269,10 @@ def add_neuropil_segmentation_and_r_values(
     extraction_h5: Path,
     img_seg: ImageSegmentation,
     imaging_plane: ImagingPlane,
-) -> None:
-    """Add neuropil segmentation masks and r-values to an ImageSegmentation object.
+    resolution: float = 1.0,
+) -> "GrayscaleImage | None":
+    """Add neuropil segmentation masks and r-values to an ImageSegmentation object,
+    and return a GrayscaleImage of the collapsed neuropil mask.
 
     Parameters
     ----------
@@ -280,6 +282,13 @@ def add_neuropil_segmentation_and_r_values(
         The NWB ImageSegmentation object to add the plane segmentation to.
     imaging_plane : ImagingPlane
         The NWB ImagingPlane associated with this segmentation.
+    resolution : float
+        Pixel resolution to set on the returned GrayscaleImage (pixels/cm).
+
+    Returns
+    -------
+    GrayscaleImage or None
+        A GrayscaleImage of the 2-D neuropil mask, or None if creation failed.
     """
     try:
         neuropil_masks, r_values = load_neuropil_masks_and_r_values(extraction_h5)
@@ -294,10 +303,41 @@ def add_neuropil_segmentation_and_r_values(
         neuropil_plane_segmentation.add_column(
             name="neuropil_r_value",
             description="Coefficients used for neuropil correction",
-            data=r_values
+            data=r_values,
+        )
+
+        neuropil_mask_2d = convert_neuropil_masks_to_image(neuropil_masks)
+        return GrayscaleImage(
+            name="neuropil_mask_image",
+            data=neuropil_mask_2d,
+            resolution=resolution,
+            description="Neuropil segmentation mask image",
         )
     except Exception as e:
         logging.warning(f"Error adding neuropil segmentation masks: {e}")
+        return None
+
+
+def convert_neuropil_masks_to_image(neuropil_masks: np.ndarray) -> np.ndarray:
+    """Collapse 3D neuropil masks into a 2D label image.
+
+    Parameters
+    ----------
+    neuropil_masks : np.ndarray
+        Boolean array of shape (n_rois, height, width).
+
+    Returns
+    -------
+    np.ndarray
+        2D array of shape (height, width) where each pixel value is the
+        1-based index of the neuropil mask that covers it (0 = no mask).
+    """
+    segmentation_mask = np.zeros(neuropil_masks.shape[1:], dtype="i2")
+    contains_neuropil = neuropil_masks.any(0)
+    segmentation_mask[contains_neuropil] = (
+        np.argmax(neuropil_masks[:, contains_neuropil], 0) + 1
+    )
+    return segmentation_mask
 
 
 def convert_rois_to_segmentation_mask(h5_file):
@@ -563,11 +603,12 @@ def nwb_ophys_single_plane(
         ):
             plane_segmentation.add_roi(image_mask=pixel_mask)
 
+    neuropil_img = None
     if segmentation_approach in (
         SegmentationApproach.SUITE2P_ANATOMICAL,
         SegmentationApproach.SUITE2P_ACTIVITY,
     ):
-        add_neuropil_segmentation_and_r_values(
+        neuropil_img = add_neuropil_segmentation_and_r_values(
             file_paths["planes"][plane_name]["extraction_h5"],
             img_seg,
             imaging_plane,
@@ -605,6 +646,7 @@ def nwb_ophys_single_plane(
         )
 
         # Try to add segmentation mask if available
+        summary_images = [avg_img, max_img]
         if segmentation_approach == SegmentationApproach.SUITE2P_ANATOMICAL:
             segmentation_mask = load_generic_group(
                 file_paths["planes"][plane_name]["extraction_h5"],
@@ -617,17 +659,16 @@ def nwb_ophys_single_plane(
                 resolution=1.0,  # Update if available
                 description="Segmentation projection of entire session",
             )
-            images = Images(
-                name="images",
-                images=[avg_img, max_img, mask_img],
-                description="Summary images of the ophys movie",
-            )
-        else:
-            images = Images(
-                name="images",
-                images=[avg_img, max_img],
-                description="Summary images of the ophys movie",
-            )
+            summary_images.append(mask_img)
+
+        if neuropil_img is not None:
+            summary_images.append(neuropil_img)
+
+        images = Images(
+            name="images",
+            images=summary_images,
+            description="Summary images of the ophys movie",
+        )
 
         ophys_module.add(images)
     except Exception as e:
@@ -879,14 +920,16 @@ def nwb_ophys(
             ],
         )
 
+        neuropil_img = None
         if segmentation_approach in (
             SegmentationApproach.SUITE2P_ANATOMICAL,
             SegmentationApproach.SUITE2P_ACTIVITY,
         ):
-            add_neuropil_segmentation_and_r_values(
+            neuropil_img = add_neuropil_segmentation_and_r_values(
                 file_paths["planes"][plane_name]["extraction_h5"],
                 img_seg,
                 imaging_plane,
+                resolution=float(plane["fov_scale_factor"]),
             )
         else:
             logging.info(
@@ -932,9 +975,13 @@ def nwb_ophys(
             description="Segmentation projection of entire session",
         )
 
+        summary_images = [avg_img, max_img, mask_img]
+        if neuropil_img is not None:
+            summary_images.append(neuropil_img)
+
         images = Images(
             name="images",
-            images=[avg_img, max_img, mask_img],
+            images=summary_images,
             description="Summary images of the two-photon movie",
         )
         ophys_module.add(images)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -255,8 +255,8 @@ def load_neuropil_masks(h5_file: Path) -> np.ndarray:
     with h5py.File(h5_file, "r") as f:
         indices = f["rois"]["neuropil_coords"][:].T
         shape = f["rois"]["shape"][:]
-    neuropil_mask = np.zeros(shape)
-    neuropil_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = 1
+    neuropil_mask = np.zeros(shape, dtype=bool)
+    neuropil_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = True
     return neuropil_mask
 
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -239,8 +239,8 @@ def load_sparse_array(h5_file):
     return pixelmasks
 
 
-def load_neuropil_masks(h5_file: Path) -> np.ndarray:
-    """Load neuropil pixel masks from the h5 file
+def load_neuropil_masks_and_r_values(h5_file: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Load neuropil pixel masks and r-values from the h5 file
 
     Parameters
     ----------
@@ -251,22 +251,27 @@ def load_neuropil_masks(h5_file: Path) -> np.ndarray:
     -------
     np.ndarray
         Dense array of shape (n_rois, height, width) with neuropil masks
+    np.ndarray
+        Array of shape (n_rois,) with r-values for each neuropil mask
     """
     with h5py.File(h5_file, "r") as f:
         indices = f["rois"]["neuropil_coords"][:].T
         shape = f["rois"]["shape"][:]
+
+        r_values = f["traces"]["neuropil_rcoef"][:]
+
     neuropil_mask = np.zeros(shape, dtype=bool)
     neuropil_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = True
-    return neuropil_mask
+    return neuropil_mask, r_values
 
 
-def add_neuropil_segmentation(
+def add_neuropil_segmentation_and_r_values(
     extraction_h5: Path,
     segmentation_approach: SegmentationApproach,
     img_seg: ImageSegmentation,
     imaging_plane: ImagingPlane,
 ) -> None:
-    """Add neuropil segmentation masks to an ImageSegmentation object.
+    """Add neuropil segmentation masks and r-values to an ImageSegmentation object.
 
     Only runs for suite2p-based segmentation approaches.
 
@@ -286,7 +291,7 @@ def add_neuropil_segmentation(
             SegmentationApproach.SUITE2P_ANATOMICAL,
             SegmentationApproach.SUITE2P_ACTIVITY,
         ):
-            neuropil_masks = load_neuropil_masks(extraction_h5)
+            neuropil_masks, r_values = load_neuropil_masks_and_r_values(extraction_h5)
             neuropil_plane_segmentation = img_seg.create_plane_segmentation(
                 name="neuropil_masks",
                 description="Neuropil segmentation masks from suite2p",
@@ -294,6 +299,12 @@ def add_neuropil_segmentation(
             )
             for neuropil_mask in neuropil_masks:
                 neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
+
+            neuropil_plane_segmentation.add_column(
+                name="Neuropil r values",
+                description="Coefficients used for neuropil correction",
+                data=r_values
+            )
         else:
             logging.info(
                 "Skipping neuropil segmentation. Currently only supported "
@@ -567,7 +578,7 @@ def nwb_ophys_single_plane(
         ):
             plane_segmentation.add_roi(image_mask=pixel_mask)
 
-    add_neuropil_segmentation(
+    add_neuropil_segmentation_and_r_values(
         file_paths["planes"][plane_name]["extraction_h5"],
         segmentation_approach,
         img_seg,
@@ -874,7 +885,7 @@ def nwb_ophys(
             ],
         )
 
-        add_neuropil_segmentation(
+        add_neuropil_segmentation_and_r_values(
             file_paths["planes"][plane_name]["extraction_h5"],
             segmentation_approach,
             img_seg,

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -301,7 +301,7 @@ def add_neuropil_segmentation_and_r_values(
                 neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
 
             neuropil_plane_segmentation.add_column(
-                name="Neuropil r values",
+                name="neuropil_r_value",
                 description="Coefficients used for neuropil correction",
                 data=r_values
             )

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pynwb
 import sparse
 import aind_nwb_utils.utils as nwb_utils
-from aind_metadata_mapper.open_ephys.utils import sync_utils as sync
+from aind_behavior_utils.sync.sync_dataset import SyncDataset
 from hdmf.common import VectorData
 from hdmf_zarr import NWBZarrIO
 from pynwb import NWBFile
@@ -1295,13 +1295,19 @@ def _sync_timestamps(sync_fp: Path) -> np.array:
     np.array
         The sync timestamps
     """
-    sync_dataset = sync.load_sync(sync_fp)
-    return sync.get_edges(
-        sync_file=sync_dataset,
-        kind="rising",
-        keys=["vsync_2p", "2p_vsync"],
-        units="seconds",
-    )
+    sync_dataset = SyncDataset(sync_fp)
+
+    try:
+        return sync_dataset.get_rising_edges(
+            line="2p_vsync",
+            units="seconds"
+        )
+    except ValueError:
+        logging.warning("Failed to find 2p_vsync line. Trying with vsync_2p")
+        return sync_dataset.get_rising_edges(
+            line="vsync_2p",
+            units="seconds"
+        )
 
 
 def get_sync_timestamps(raw_path: Path) -> np.array:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -294,6 +294,12 @@ def add_neuropil_segmentation(
             )
             for neuropil_mask in neuropil_masks:
                 neuropil_plane_segmentation.add_roi(image_mask=neuropil_mask)
+        else:
+            logging.info(
+                "Skipping neuropil segmentation. Currently only supported "
+                "for suite2p-based segmentation approaches. "
+                f"Segmentation approach used: {segmentation_approach}"
+            )
     except Exception as e:
         logging.warning(f"Error adding neuropil segmentation masks: {e}")
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -293,7 +293,7 @@ def add_neuropil_segmentation_and_r_values(
     try:
         neuropil_masks, r_values = load_neuropil_masks_and_r_values(extraction_h5)
         neuropil_plane_segmentation = img_seg.create_plane_segmentation(
-            name="neuropil_masks",
+            name="neuropil_table",
             description="Neuropil segmentation masks from suite2p",
             imaging_plane=imaging_plane,
         )

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG GIT_ASKPASS
 ARG GIT_ACCESS_TOKEN
-COPY git-askpass /
+COPY git-ask-pass /
 
 RUN apt-get update
 
@@ -22,7 +22,7 @@ RUN pip install -U --no-cache-dir \
 	pynwb==2.8.3 \
     tifffile \
     imageio \
-    aind-metadata-mapper \
+    aind-behavior-utils \
     aind-nwb-utils==0.1.6\
     nwbwidgets \
     numpy==1.26.4 \


### PR DESCRIPTION
Starting a PR for this. This will probably need some iteration. Tries to address: https://github.com/AllenNeuralDynamics/aind-physio-arch/issues/974

Based on this teams message from Johannes:

>  that's specific to Suite2p, CaImAn (and other methods) don't have a neuropil mask for each ROI. If the dataset exists it's "rois/neuropil_coords" in extraction.h5. Same spare COO representation as we use for ROIs, just that there is no "rois/neuropil_data" cause all the values are 1.

The attempt to add the neuropil masks should only occur if the segmentation approach is Suite2p (the actual check might need to be modified in the code).

Running some sample tests with this from this asset in code ocean - `multiplane-ophys_832701_2026-03-03_09-52-04_processed_2026-03-04_11-30-44`, I tried to visualize the neuropil masks for one of the imaging planes, and mimic pulling it from the nwb. This is after doing a max projection on the masks:

<img width="430" height="418" alt="image" src="https://github.com/user-attachments/assets/b1aff591-3b8a-4335-ad12-2a1a0e48bb2b" />


I still need to do integration testing with the whole pipeline end to end

 

