### PR TITLE
Tolerate missing SUITE2P_ROI_STATS keys (CaImAn or Suite2p v1.1 extraction)

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -250,13 +250,9 @@ def load_available_suite2p_stats(extraction_h5: Path) -> dict:
         Mapping of stat name to its per-ROI array, for whichever stats
         are present.
     """
-    stats = {}
-    for stat in SUITE2P_ROI_STATS:
-        try:
-            stats[stat] = load_generic_group(extraction_h5, h5_group="rois", h5_key=stat)
-        except KeyError:
-            pass
-    return stats
+    with h5py.File(extraction_h5, "r") as f:
+        rois_group = f.get("rois", {})
+        return {stat: rois_group[stat][:] for stat in SUITE2P_ROI_STATS if stat in rois_group}
 
 
 def load_sparse_array(h5_file):

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -232,6 +232,33 @@ def load_generic_group(h5_file: Path, h5_group=None, h5_key=None) -> np.array:
             return f[h5_key][:]
 
 
+def load_available_suite2p_stats(extraction_h5: Path) -> dict:
+    """Load whichever SUITE2P_ROI_STATS keys are actually present.
+
+    CaImAn-based extraction writes none of these stats, and Suite2p v1.1
+    no longer computes "solidity", so callers must not assume all of
+    SUITE2P_ROI_STATS are present in the extraction file's rois/ group.
+
+    Parameters
+    ----------
+    extraction_h5: Path
+        Path to extraction_h5
+
+    Returns
+    -------
+    (dict)
+        Mapping of stat name to its per-ROI array, for whichever stats
+        are present.
+    """
+    stats = {}
+    for stat in SUITE2P_ROI_STATS:
+        try:
+            stats[stat] = load_generic_group(extraction_h5, h5_group="rois", h5_key=stat)
+        except KeyError:
+            pass
+    return stats
+
+
 def load_sparse_array(h5_file):
     """Obtain pixel masks from the h5 file
 
@@ -555,16 +582,11 @@ def nwb_ophys_single_plane(
         except Exception:
             cellpose_soma_probability = None
 
-        # Per-ROI suite2p morphology stats (always present in the
-        # extraction file's rois/ group).
-        suite2p_stats = {
-            stat: load_generic_group(
-                file_paths["planes"][plane_name]["extraction_h5"],
-                h5_group="rois",
-                h5_key=stat,
-            )
-            for stat in SUITE2P_ROI_STATS
-        }
+        # Per-ROI suite2p morphology stats. Not all of SUITE2P_ROI_STATS
+        # are necessarily present -- see load_available_suite2p_stats.
+        suite2p_stats = load_available_suite2p_stats(
+            file_paths["planes"][plane_name]["extraction_h5"]
+        )
 
         columns = [
             VectorData(
@@ -599,7 +621,7 @@ def nwb_ophys_single_plane(
             "dendrite_probability",
             "cellpose_soma_probability",
         ]
-        for stat in SUITE2P_ROI_STATS:
+        for stat in suite2p_stats:
             columns.append(
                 VectorData(
                     name=stat,
@@ -632,10 +654,7 @@ def nwb_ophys_single_plane(
                 is_dendrite=dendrite_predictions[idx],
                 dendrite_probability=dendrite_probabilities[idx][-1],
                 cellpose_soma_probability=cellpose_value,
-                **{
-                    stat: suite2p_stats[stat][idx]
-                    for stat in SUITE2P_ROI_STATS
-                },
+                **{stat: values[idx] for stat, values in suite2p_stats.items()},
             )
     except Exception as e:
         logging.warning(f"Error adding ROIs with classifier data: {e}")
@@ -953,16 +972,11 @@ def nwb_ophys(
         except Exception:
             cellpose_soma_probability = None
 
-        # Per-ROI suite2p morphology stats (always present in the
-        # extraction file's rois/ group).
-        suite2p_stats = {
-            stat: load_generic_group(
-                file_paths["planes"][plane_name]["extraction_h5"],
-                h5_group="rois",
-                h5_key=stat,
-            )
-            for stat in SUITE2P_ROI_STATS
-        }
+        # Per-ROI suite2p morphology stats. Not all of SUITE2P_ROI_STATS
+        # are necessarily present -- see load_available_suite2p_stats.
+        suite2p_stats = load_available_suite2p_stats(
+            file_paths["planes"][plane_name]["extraction_h5"]
+        )
 
         columns = [
             VectorData(
@@ -997,7 +1011,7 @@ def nwb_ophys(
             "dendrite_probability",
             "cellpose_soma_probability",
         ]
-        for stat in SUITE2P_ROI_STATS:
+        for stat in suite2p_stats:
             columns.append(
                 VectorData(
                     name=stat,
@@ -1104,10 +1118,7 @@ def nwb_ophys(
                 is_dendrite=dendrite_predictions[idx],
                 dendrite_probability=dendrite_probabilities[idx][-1],
                 cellpose_soma_probability=cellpose_value,
-                **{
-                    stat: suite2p_stats[stat][idx]
-                    for stat in SUITE2P_ROI_STATS
-                },
+                **{stat: values[idx] for stat, values in suite2p_stats.items()},
             )
 
         roi_traces, roi_names = load_signals(


### PR DESCRIPTION
Fixes #78.

## Problem

`run_capsule.py` assumed all of `SUITE2P_ROI_STATS` (`aspect_ratio`, `compact`, `solidity`, `radius`, `footprint`) are always present in the extraction file's `rois/` group, and loaded them unconditionally via `load_generic_group()`, which raises `KeyError` immediately on a missing key.

That assumption no longer holds:
- **CaImAn-based extraction** (`greedy_roi`/`corr_pnr` init, or CNMF/CNMF-E neuropil refinement): none of these stats are ever written.
- **Suite2p v1.1** (the recent `aind-ophys-extraction` migration): `solidity` is no longer computed at all; the other four are still present.

Two call sites do this load:
- `nwb_ophys` — no error handling at all, so it crashed the whole run outright.
- `nwb_ophys_single_plane` — already wrapped in a broad `try/except` that falls back to a bare ROI table on *any* exception, so it didn't crash, but silently dropped **all** classifier + stats columns even when only one stat was missing.

## Fix

New `load_available_suite2p_stats()` helper opens the extraction file once and keeps only whichever of `SUITE2P_ROI_STATS` actually exist in the `rois/` group. Both call sites now use it, and build their `columns`/`colnames`/`add_roi(**{...})` from whatever's actually available instead of the full constant. Net effect:
- CaImAn-based extraction files get a valid NWB file with zero suite2p-stat columns (instead of crashing).
- Suite2p v1.1 files keep 4 of 5 stat columns (instead of losing all of them via the existing fallback, or crashing).

## Testing

- `python -m py_compile code/run_capsule.py` — clean.
- `flake8` (repo's `.flake8`, max-line-length=100) — clean.
- Verified `load_available_suite2p_stats()` against synthetic h5 files covering all three cases (all stats present, Suite2p v1.1 missing `solidity`, CaImAn with none of the stats).
- No existing test suite in this repo to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)